### PR TITLE
Add condition.else block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop environment:**
+
+<!--
+Please paste the ouput of the following command in your issue. It helps us identify your environment and act more quickly to solve your problem.
+
+$ npx envinfo --system --binaries --browsers
+
+If the problem happens in a specific browser, please state which browser.
+--->
+
+**Smartphone environment:**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'New Feature'
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -1,0 +1,18 @@
+---
+name: Question
+about: Ask a question you had while building a store
+labels: question
+---
+
+**What are you trying to accomplish? Please describe.**
+A clear and concise description of what is your question and what you're trying to accomplish in the end is.
+
+**What have you tried so far?**
+A clear and concise description of what you tried to do already.
+
+**Additional info**
+Add extra content here (code samples, screenshots,...)
+
+| Account        | Workspace        |
+| -------------- | ---------------- |
+| `your account` | `your workspace` |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,7 @@
-#### What problem is this solving?
+**What problem is this solving?**
 
 <!--- What is the motivation and context for this change? -->
 
-#### How should this be manually tested?
+**How should this be manually tested?**
 
-[Workspace](url)
-
-#### Checklist/Reminders
-
-- [ ] Updated `README.md`.
-- [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
-- [ ] Updated/created tests (important for bug fixes).
-- [ ] Deleted the workspace after merging this PR (if applicable).
-
-#### Screenshots or example usage
-
-#### Type of changes
-
-<!--- Add a ✔️ where applicable -->
-✔️ | Type of Change
----|---
-_ | Bug fix <!-- a non-breaking change which fixes an issue -->
-_ | New feature <!-- a non-breaking change which adds functionality -->
-_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
-_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
-
-#### Notes
-
-<!-- Put any relevant information that doesn't fit in the other sections here. -->
+**Screenshots or example usage:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- `condition` and `condition.else` and `condition-layout.product` blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.2.2] - 2019-12-23
-
-## [0.2.1] - 2019-11-19
-
-## [0.2.0] - 2019-11-18
-
-## [0.1.0] - 2019-09-23
-### Added
-- Test example for VTEX IO app.
-
-## Changed
-- Removed `injectIntl` from example
-
-- **Component** Create the VTEX Store Component _IO Base App_

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ The app exports three kinds of block:
 
 - `condition-layout.{context}` - These blocks are responsible for holding your condition blocks and providing the appropriate context.
 - `condition` - This blocks hold the condition logic and childrens to be displayed given the condition resolves to true.
-- `condition.default` - This block can be used to render some content if no `condition` block was matched inside a `condition.layout`.
+- `condition.else` - This block can be used to render some content if no `condition` block was matched inside a `condition.layout`.
 
 ### `condition-layout`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,11 @@ The condition layout app allows to conditionally render a block given certain co
 
 ## Configuration
 
-The app exports two kinds of block:
+The app exports three kinds of block:
 
 - `condition-layout.{context}` - These blocks are responsible for holding your condition blocks and providing the appropriate context.
 - `condition` - This blocks hold the condition logic and childrens to be displayed given the condition resolves to true.
+- `condition.default` - This block can be used to render some content if no `condition` block was matched inside a `condition.layout`.
 
 ### `condition-layout`
 

--- a/react/Condition.ts
+++ b/react/Condition.ts
@@ -1,7 +1,7 @@
-import { FC, useMemo } from 'react'
+import { FC, useMemo, useEffect } from 'react'
 
 import { testConditions } from './modules/conditions'
-import { useCondition } from './ConditionContext'
+import { useConditionContext, useConditionDispatch } from './ConditionContext'
 
 interface Props {
   conditions?: Conditions
@@ -9,7 +9,8 @@ interface Props {
 }
 
 const Condition: FC<Props> = ({ children, conditions, match }) => {
-  const { values, subjects } = useCondition()
+  const { values, subjects } = useConditionContext()
+  const dispatch = useConditionDispatch()
 
   const matches = useMemo(() => {
     if (conditions == null || values == null || subjects == null) {
@@ -26,6 +27,13 @@ const Condition: FC<Props> = ({ children, conditions, match }) => {
 
     return matches
   }, [conditions, match, subjects, values])
+
+  useEffect(() => {
+    dispatch({
+      type: 'UPDATE_MATCH',
+      payload: { matches: !!matches },
+    })
+  }, [dispatch, matches])
 
   if (conditions == null) {
     // TODO: Handle error better

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -1,6 +1,13 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, Dispatch } from 'react'
+
+import Noop from './Noop'
+
+type Action<K, V = void> = V extends void ? { type: K } : { type: K } & V
+
+type Actions = Action<'UPDATE_MATCH', { payload: { matches: boolean } }>
 
 type ConditionContextValue = {
+  matched: null | boolean
   subjects: GenericSubjects
   values: Values
 }
@@ -9,7 +16,26 @@ export const ConditionContext = createContext<ConditionContextValue>(
   {} as ConditionContextValue
 )
 
-export function useCondition() {
+export const ConditionDispatchContext = createContext<Dispatch<Actions>>(Noop)
+
+export function reducer(prevState: ConditionContextValue, action: Actions) {
+  if (action.type === 'UPDATE_MATCH') {
+    if (prevState.matched === action.payload.matches) {
+      return prevState
+    }
+
+    return {
+      ...prevState,
+      // we use the pipe operator because we want to explicitly consider false values here
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      matched: prevState.matched || action.payload.matches,
+    }
+  }
+
+  return prevState
+}
+
+export function useConditionContext() {
   const ctx = useContext(ConditionContext)
 
   if (ctx == null) {
@@ -19,4 +45,8 @@ export function useCondition() {
   }
 
   return ctx
+}
+
+export function useConditionDispatch() {
+  return useContext(ConditionDispatchContext)
 }

--- a/react/ConditionLayout.tsx
+++ b/react/ConditionLayout.tsx
@@ -1,0 +1,30 @@
+import React, { FC, useReducer } from 'react'
+
+import {
+  ConditionDispatchContext,
+  ConditionContext,
+  reducer,
+} from './ConditionContext'
+
+type Props = {
+  values: Values
+  subjects: GenericSubjects
+}
+
+const ConditionLayout: FC<Props> = ({ children, subjects, values }) => {
+  const [state, dispatch] = useReducer(reducer, {
+    matched: null,
+    subjects,
+    values,
+  })
+
+  return (
+    <ConditionContext.Provider value={state}>
+      <ConditionDispatchContext.Provider value={dispatch}>
+        {children}
+      </ConditionDispatchContext.Provider>
+    </ConditionContext.Provider>
+  )
+}
+
+export default ConditionLayout

--- a/react/Default.ts
+++ b/react/Default.ts
@@ -1,0 +1,14 @@
+import { FC } from 'react'
+
+import { useConditionContext } from './ConditionContext'
+
+const Default: FC = ({ children }) => {
+  const { matched } = useConditionContext()
+  if (matched !== false) {
+    return null
+  }
+
+  return children as any
+}
+
+export default Default

--- a/react/Product.tsx
+++ b/react/Product.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { useProduct } from 'vtex.product-context'
 
-import { ConditionContext } from './ConditionContext'
+import ConditionLayout from './ConditionLayout'
 
 const SUBJECTS = {
   productId: {
@@ -26,8 +26,6 @@ const SUBJECTS = {
   },
 } as const
 
-export type ProductSubjects = typeof SUBJECTS
-
 const Product: FC = ({ children }) => {
   const { product, selectedItem } = useProduct() as any
 
@@ -41,9 +39,9 @@ const Product: FC = ({ children }) => {
   }
 
   return (
-    <ConditionContext.Provider value={{ values, subjects: SUBJECTS }}>
+    <ConditionLayout values={values} subjects={SUBJECTS}>
       {children}
-    </ConditionContext.Provider>
+    </ConditionLayout>
   )
 }
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,6 +6,10 @@
     "component": "Condition",
     "composition": "children"
   },
+  "condition.default": {
+    "component": "Default",
+    "composition": "children"
+  },
   "condition-layout.product": {
     "component": "Product",
     "composition": "children"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,7 +6,7 @@
     "component": "Condition",
     "composition": "children"
   },
-  "condition.default": {
+  "condition.else": {
     "component": "Default",
     "composition": "children"
   },


### PR DESCRIPTION
#### What problem is this solving?

Add the `condition.default`

#### How should this be manually tested?

1) https://kiwi--storecomponents.myvtex.com/traveler-backpack/p should show `e ai boy`
2) https://kiwi--storecomponents.myvtex.com/rustic-striped-vase/p should show `default moleque`

PDP block config:

```json
{
  "store.product": {
    "children": ["condition-layout.product"]
  },
  "condition-layout.product": {
    "children": ["condition#foo", "condition.else#foo"]
  },
  "condition#foo": {
    "props": {
      "match": "any",
      "conditions": [
        {
          "subject": "productId",
          "object": "12"
        },
        {
          "subject": "selectedItemId",
          "object": "36"
        },
        {
          "subject": "productClusters",
          "verb": "contains",
          "object": "1170"
        }
      ]
    },
    "children": ["rich-text#eita"]
  },
  "rich-text#eita": {
    "props": {
      "text": "eai boy"
    }
  },
  "condition.else#foo": {
    "children": ["rich-text#eita2"]
  },
  "rich-text#eita2": {
    "props": {
      "text": "default moleque"
    }
  }
}

```

#### Checklist/Reminders

- [x] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).
