### PR TITLE
Prevent error if array not available yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent exception when an array subject is not available yet.
 
 ## [1.0.0] - 2020-04-06
 

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -7,7 +7,7 @@ type Action<K, V = void> = V extends void ? { type: K } : { type: K } & V
 type Actions = Action<'UPDATE_MATCH', { payload: { matches: boolean } }>
 
 type ConditionContextValue = {
-  matched: null | boolean
+  matched: boolean | undefined
   subjects: GenericSubjects
   values: Values
 }
@@ -26,9 +26,7 @@ export function reducer(prevState: ConditionContextValue, action: Actions) {
 
     return {
       ...prevState,
-      // we use the pipe operator because we want to explicitly consider false values here
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      matched: prevState.matched || action.payload.matches,
+      matched: !!prevState.matched || action.payload.matches,
     }
   }
 

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -26,7 +26,7 @@ export function reducer(prevState: ConditionContextValue, action: Actions) {
 
     return {
       ...prevState,
-      matched: !!prevState.matched || action.payload.matches,
+      matched: Boolean(prevState.matched) || action.payload.matches,
     }
   }
 

--- a/react/ConditionLayout.tsx
+++ b/react/ConditionLayout.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const ConditionLayout: FC<Props> = ({ children, subjects, values }) => {
   const [state, dispatch] = useReducer(reducer, {
-    matched: null,
+    matched: undefined,
     subjects,
     values,
   })

--- a/react/modules/conditions.ts
+++ b/react/modules/conditions.ts
@@ -25,11 +25,9 @@ const testArrayCondition = (
   values: Record<string, any[]>,
   condition: ArrayCondition
 ) => {
-  // TODO: prevent potential errors here w invalid subject
-
   const subjectId = subject.id ?? 'id'
-  const ids = values[condition.subject].map(item => String(item[subjectId]))
-  const matches = ids.includes(String(condition.object))
+  const ids = values[condition.subject]?.map(item => String(item[subjectId]))
+  const matches = ids?.includes(String(condition.object))
 
   // TODO: error messages on wrong verbs
   return (condition.verb === 'contains' || !condition.verb) === matches


### PR DESCRIPTION
**What problem is this solving?**

This PR fixes when a subject of type array is not available yet.

Related to and closes https://github.com/vtex-apps/store-discussion/issues/265

**How should this be manually tested?**

Check the workspace from the issue above: 
https://condition--tackoftheday.myvtex.com/dettol-1-l-dettol-antiseptic-dettol110/p

**Screenshots or example usage:**

n/a