### PR TITLE
Dispatch context values update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update the condition context `values` when it's externally updated.
 
 ## [1.1.0] - 2020-04-13
 ### Added

--- a/react/Condition.ts
+++ b/react/Condition.ts
@@ -24,7 +24,7 @@ const Condition: StorefrontFunctionComponent<ConditionProps> = ({
     }
 
     if (conditions == null || values == null || subjects == null) {
-      return null
+      return undefined
     }
 
     const hasMatched = testConditions({

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -5,7 +5,7 @@ import Noop from './Noop'
 type Action<K, V = void> = V extends void ? { type: K } : { type: K } & V
 
 type Actions =
-  | Action<'UPDATE_MATCH', { payload: { matches: boolean | null } }>
+  | Action<'UPDATE_MATCH', { payload: { matches: boolean | undefined } }>
   | Action<'SET_VALUES', { payload: { values: Record<string, any> } }>
 
 type ConditionContextValue = {

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -24,31 +24,30 @@ export function reducer(
   prevState: ConditionContextValue,
   action: Actions
 ): ConditionContextValue {
-  if (action.type === 'SET_VALUES') {
-    return {
-      ...prevState,
-      values: action.payload.values,
+  switch (action.type) {
+    case 'SET_VALUES': {
+      return {
+        ...prevState,
+        values: action.payload.values,
+      }
     }
-  }
 
-  if (action.type === 'UPDATE_MATCH') {
-    const { matches } = action.payload
+    case 'UPDATE_MATCH': {
+      const { matches } = action.payload
 
-    if (prevState.matched === matches || matches == null) {
+      if (prevState.matched === matches || matches == null) {
+        return prevState
+      }
+
+      return {
+        ...prevState,
+        matched: Boolean(prevState.matched) || matches,
+      }
+    }
+
+    default:
       return prevState
-    }
-
-    if (prevState.matched == null) {
-      return { ...prevState, matched: matches }
-    }
-
-    return {
-      ...prevState,
-      matched: Boolean(prevState.matched) || matches,
-    }
   }
-
-  return prevState
 }
 
 export function useConditionContext() {

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -28,6 +28,9 @@ export function reducer(
     case 'SET_VALUES': {
       return {
         ...prevState,
+        // we need to invalidate the matched property after updating the values
+        // because it's possible for none of the conditions to match the new values
+        matched: undefined,
         values: action.payload.values,
       }
     }

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -4,7 +4,9 @@ import Noop from './Noop'
 
 type Action<K, V = void> = V extends void ? { type: K } : { type: K } & V
 
-type Actions = Action<'UPDATE_MATCH', { payload: { matches: boolean | null } }>
+type Actions =
+  | Action<'UPDATE_MATCH', { payload: { matches: boolean | null } }>
+  | Action<'SET_VALUES', { payload: { values: Record<string, any> } }>
 
 type ConditionContextValue = {
   matched: boolean | undefined
@@ -22,9 +24,16 @@ export function reducer(
   prevState: ConditionContextValue,
   action: Actions
 ): ConditionContextValue {
-  const { matches } = action.payload
+  if (action.type === 'SET_VALUES') {
+    return {
+      ...prevState,
+      values: action.payload.values,
+    }
+  }
 
   if (action.type === 'UPDATE_MATCH') {
+    const { matches } = action.payload
+
     if (prevState.matched === matches || matches == null) {
       return prevState
     }
@@ -35,7 +44,7 @@ export function reducer(
 
     return {
       ...prevState,
-      matched: prevState.matched || matches,
+      matched: Boolean(prevState.matched) || matches,
     }
   }
 

--- a/react/ConditionLayout.tsx
+++ b/react/ConditionLayout.tsx
@@ -23,6 +23,9 @@ const ConditionLayout: StorefrontFunctionComponent<Props> = ({
     values,
   })
 
+  // we use a useEffect that skips the first render
+  // because we don't want to update the `values` twice
+  // at component initialization.
   useEffectSkipFirstRender(() => {
     dispatch({
       type: 'SET_VALUES',

--- a/react/ConditionLayout.tsx
+++ b/react/ConditionLayout.tsx
@@ -5,6 +5,7 @@ import {
   ConditionContext,
   reducer,
 } from './ConditionContext'
+import { useEffectSkipFirstRender } from './modules/useEffectSkipFirstRender'
 
 type Props = {
   values: Values
@@ -21,6 +22,13 @@ const ConditionLayout: StorefrontFunctionComponent<Props> = ({
     subjects,
     values,
   })
+
+  useEffectSkipFirstRender(() => {
+    dispatch({
+      type: 'SET_VALUES',
+      payload: { values },
+    })
+  }, [values])
 
   return (
     <ConditionContext.Provider value={state}>

--- a/react/modules/useEffectSkipFirstRender.ts
+++ b/react/modules/useEffectSkipFirstRender.ts
@@ -1,8 +1,8 @@
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, DependencyList, EffectCallback } from 'react'
 
 export const useEffectSkipFirstRender = (
-  fn: React.EffectCallback,
-  deps: React.DependencyList
+  fn: EffectCallback,
+  deps: DependencyList
 ) => {
   const isFirstRender = useRef(true)
 

--- a/react/modules/useEffectSkipFirstRender.ts
+++ b/react/modules/useEffectSkipFirstRender.ts
@@ -1,0 +1,17 @@
+import { useRef, useEffect } from 'react'
+
+export const useEffectSkipFirstRender = (
+  fn: React.EffectCallback,
+  deps: React.DependencyList
+) => {
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    return fn()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+}


### PR DESCRIPTION
**What problem is this solving?**

Some values from the `product-context` are asynchronously defined, such as `categoryTree`. Previous to this PR, the condition context wasn't receiving the updated values dictionary.

**How should this be manually tested?**

https://condition--tackoftheday.myvtex.com/horseware-womens-softie-socks-triangle-print-cohfcr-8tri/p

Look for 
![image](https://user-images.githubusercontent.com/12702016/78942414-12f2c200-7a90-11ea-9a63-7c3483369f48.png)
