### PR TITLE
Fix/context match update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `matched` context value not being recaculated after its invalidation.
 
 ## [1.1.1] - 2020-04-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `matched` context value not being recaculated after its invalidation.
+- `matched` context value not being recalculated after its invalidation.
 
 ## [1.1.1] - 2020-04-13
 ### Fixed

--- a/react/Condition.ts
+++ b/react/Condition.ts
@@ -5,7 +5,7 @@ import { useConditionContext, useConditionDispatch } from './ConditionContext'
 
 export interface ConditionProps {
   conditions?: Conditions
-  match: MatchType
+  match?: MatchType
   enabled?: boolean
 }
 
@@ -42,7 +42,9 @@ const Condition: StorefrontFunctionComponent<ConditionProps> = ({
       type: 'UPDATE_MATCH',
       payload: { matches },
     })
-  }, [dispatch, matches])
+    // we depend on `values` to trigger an update of the context `matched` value
+    // TODO: maybe rewrite this whole thing
+  }, [dispatch, matches, values])
 
   if (conditions == null) {
     // TODO: Handle error better
@@ -54,7 +56,7 @@ const Condition: StorefrontFunctionComponent<ConditionProps> = ({
     return null
   }
 
-  return (children as any) ?? null
+  return (children as never) ?? null
 }
 
 export default Condition

--- a/react/__mocks__/vtex.product-context.ts
+++ b/react/__mocks__/vtex.product-context.ts
@@ -1,0 +1,1 @@
+export const useProduct = jest.fn()

--- a/react/__tests__/Condition.tsx
+++ b/react/__tests__/Condition.tsx
@@ -1,0 +1,184 @@
+import * as React from 'react'
+import { useProduct } from 'vtex.product-context'
+import { render } from '@vtex/test-tools/react'
+
+import ConditionLayout from '../ConditionLayoutProduct'
+import ConditionProduct from '../ConditionProduct'
+import ConditionElse from '../ConditionElse'
+
+type ProductContext = {
+  product: {
+    productId: string
+    categoryId: string
+    brandId: string
+    productClusters: string[]
+    categoryTree: string[]
+  }
+  selectedItem: {
+    itemId: string
+  }
+}
+
+const mockedUseProduct = useProduct as jest.Mock<ProductContext>
+
+function getMockedProduct({ skuId = '37' }) {
+  return {
+    product: {
+      productId: 'productId',
+      categoryId: 'categoryId',
+      brandId: 'brandId',
+      productClusters: ['productClusters'],
+      categoryTree: ['categoryTree'],
+    },
+    selectedItem: {
+      itemId: skuId,
+    },
+  }
+}
+
+test('Renders a condition that resolves to true', () => {
+  mockedUseProduct.mockImplementation(() => getMockedProduct({ skuId: '37' }))
+
+  const { queryByText } = render(
+    <ConditionLayout>
+      <ConditionProduct
+        conditions={[
+          {
+            subject: 'selectedItemId',
+            verb: 'is',
+            object: '37',
+          },
+        ]}
+      >
+        Hooray!
+      </ConditionProduct>
+    </ConditionLayout>
+  )
+
+  expect(queryByText(/Hooray!/)).toBeTruthy()
+})
+
+test('Renders the else block if no condition match', () => {
+  mockedUseProduct.mockImplementation(() => getMockedProduct({ skuId: '37' }))
+
+  const { queryByText } = render(
+    <ConditionLayout>
+      <ConditionProduct
+        conditions={[
+          {
+            subject: 'selectedItemId',
+            verb: 'is',
+            object: 'foo',
+          },
+        ]}
+      >
+        Hooray!
+      </ConditionProduct>
+      <ConditionElse>Oh no!</ConditionElse>
+    </ConditionLayout>
+  )
+
+  expect(queryByText(/Hooray!/)).toBeFalsy()
+  expect(queryByText(/Oh no!/)).toBeTruthy()
+})
+
+test("Doesn't render the else block if some condition match", () => {
+  mockedUseProduct.mockImplementation(() => getMockedProduct({ skuId: '37' }))
+
+  const { queryByText } = render(
+    <ConditionLayout>
+      <ConditionProduct
+        conditions={[
+          {
+            subject: 'selectedItemId',
+            verb: 'is',
+            object: '37',
+          },
+        ]}
+      >
+        Hooray!
+      </ConditionProduct>
+      <ConditionElse>Oh no!</ConditionElse>
+    </ConditionLayout>
+  )
+
+  expect(queryByText(/Hooray!/)).toBeTruthy()
+  expect(queryByText(/Oh no!/)).toBeFalsy()
+})
+
+test('Switches from rendering a matched condition to the else component', () => {
+  mockedUseProduct.mockImplementation(() => getMockedProduct({ skuId: '37' }))
+
+  const layout = (
+    <ConditionLayout>
+      <ConditionProduct
+        conditions={[
+          {
+            subject: 'selectedItemId',
+            verb: 'is',
+            object: '37',
+          },
+        ]}
+      >
+        Hooray!
+      </ConditionProduct>
+      <ConditionElse>Oh no!</ConditionElse>
+    </ConditionLayout>
+  )
+
+  const { queryByText, rerender } = render(layout)
+
+  expect(queryByText(/Hooray!/)).toBeTruthy()
+  expect(queryByText(/Oh no!/)).toBeFalsy()
+
+  mockedUseProduct.mockImplementation(() => ({
+    product: {
+      productId: 'productId',
+      categoryId: 'categoryId',
+      brandId: 'brandId',
+      productClusters: ['productClusters'],
+      categoryTree: ['categoryTree'],
+    },
+    selectedItem: {
+      itemId: '370',
+    },
+  }))
+
+  rerender(layout)
+
+  expect(queryByText(/Hooray!/)).toBeFalsy()
+  expect(queryByText(/Oh no!/)).toBeTruthy()
+})
+
+test('Switches from rendering the else component to a matched condition component', () => {
+  mockedUseProduct.mockImplementation(() => getMockedProduct({ skuId: '37' }))
+
+  const layout = (
+    <ConditionLayout>
+      <ConditionProduct
+        conditions={[
+          {
+            subject: 'selectedItemId',
+            verb: 'is',
+            object: '370',
+          },
+        ]}
+      >
+        Hooray!
+      </ConditionProduct>
+      <ConditionElse>Oh no!</ConditionElse>
+    </ConditionLayout>
+  )
+
+  const { queryByText, rerender } = render(layout)
+
+  expect(queryByText(/Hooray!/)).toBeFalsy()
+  expect(queryByText(/Oh no!/)).toBeTruthy()
+
+  mockedUseProduct.mockImplementation(() => getMockedProduct({ skuId: '370' }))
+
+  rerender(layout)
+
+  expect(queryByText(/Hooray!/)).toBeTruthy()
+  expect(queryByText(/Oh no!/)).toBeFalsy()
+})

--- a/react/package.json
+++ b/react/package.json
@@ -13,6 +13,7 @@
     "react-intl": "^4.3.1"
   },
   "devDependencies": {
+    "@apollo/react-testing": "^3.1.4",
     "@types/classnames": "^2.2.10",
     "@types/jest": "^25.1.5",
     "@types/node": "^13.11.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -51,6 +51,15 @@
     "@apollo/react-hooks" "^3.1.4"
     tslib "^1.10.0"
 
+"@apollo/react-testing@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-3.1.4.tgz#f2e1b9b65a0bd773facf54db4fdb5995d162a72a"
+  integrity sha512-1eKjN36UfIAnBVmfLbl12vQ/eCjTqYdaU95chGIQzT2uHd5BnasJu0z+MwXBrEs57A9WY9mFvLZxdjzQJXaacA==
+  dependencies:
+    "@apollo/react-common" "^3.1.4"
+    fast-json-stable-stringify "^2.0.0"
+    tslib "^1.10.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"


### PR DESCRIPTION
**What problem is this solving?**

After the `values` from a `conditional-layout` change, the context's `matched` value is set to `undefined` and every `Condition` recalculates if they match or not. However, they weren't `dispatching` the new result because they didn't necessarily change to another value.  

**How should this be manually tested?**

1) https://denise--storecomponents.myvtex.com/classic-shoes/p?skuId=37
2) Switch between skus and check if the behavior is consisting.