### PR TITLE
Prevent infinite loop from changing the values in every render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent infinite loop from changing the `values` reference in every render.
 
 ## [1.1.4] - 2020-05-05
 ### Fixed

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useProduct } from 'vtex.product-context'
 
 import ConditionLayout from './ConditionLayout'
@@ -28,17 +28,34 @@ export const PRODUCT_SUBJECTS = {
 
 const Product: StorefrontFunctionComponent = ({ children }) => {
   const { product, selectedItem } = useProduct() as any
+  const { productId, categoryId, brandId, productClusters, categoryTree } =
+    product ?? {}
+  const { itemId: selectedItemId } = selectedItem ?? {}
+
+  // We use a useMemo to modify the a condition layout "values"
+  // only when some of the context props change.
+  const values = useMemo(
+    () => ({
+      productId,
+      categoryId,
+      brandId,
+      productClusters,
+      categoryTree,
+      selectedItemId,
+    }),
+    [
+      brandId,
+      categoryId,
+      categoryTree,
+      productClusters,
+      productId,
+      selectedItemId,
+    ]
+  )
 
   // Sometimes it takes a while for useProduct() to return the correct results
-  if (product == null || selectedItem == null) return null
-
-  const values = {
-    productId: product.productId,
-    categoryId: product.categoryId,
-    brandId: product.brandId,
-    productClusters: product.productClusters,
-    categoryTree: product.categoryTree,
-    selectedItemId: selectedItem.itemId,
+  if (values.selectedItemId == null || values.productId == null) {
+    return null
   }
 
   return (


### PR DESCRIPTION
**What problem is this solving?**

Fixes an infinite loop issue caused by constantly recreating the reference to the `values` object. 

Story: https://app.clubhouse.io/vtex/story/36984/sparkles-condition-layout-flickering

**How should this be manually tested?**

1) https://lhx--gympassus.myvtex.com/chalk-remover-609/p?skuId=1354
2) login via dm
3) Check if the page loads and the sku selector doesn't flicker.

**Screenshots or example usage:**

![image](https://user-images.githubusercontent.com/12702016/81212392-3afc1500-8fab-11ea-943c-9e333bb245b2.png)
