### PR TITLE
Prevent condition layout from render nothing after updating the values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent the `ConditionLayout` from rendering nothing after changing the `values` from its context.
 
 ## [1.1.5] - 2020-05-06
 ### Fixed

--- a/react/ConditionContext.ts
+++ b/react/ConditionContext.ts
@@ -12,6 +12,7 @@ type ConditionContextValue = {
   matched: boolean | undefined
   subjects: GenericSubjects
   values: Values
+  considerMatchedValue: boolean
 }
 
 export const ConditionContext = createContext<ConditionContextValue>(
@@ -30,7 +31,7 @@ export function reducer(
         ...prevState,
         // we need to invalidate the matched property after updating the values
         // because it's possible for none of the conditions to match the new values
-        matched: undefined,
+        considerMatchedValue: false,
         values: action.payload.values,
       }
     }
@@ -42,9 +43,14 @@ export function reducer(
         return prevState
       }
 
+      const matchedValue = prevState.considerMatchedValue
+        ? prevState.matched
+        : undefined
+
       return {
         ...prevState,
-        matched: Boolean(prevState.matched) || matches,
+        considerMatchedValue: true,
+        matched: Boolean(matchedValue) || matches,
       }
     }
 

--- a/react/ConditionLayout.tsx
+++ b/react/ConditionLayout.tsx
@@ -21,6 +21,7 @@ const ConditionLayout: StorefrontFunctionComponent<Props> = ({
     matched: undefined,
     subjects,
     values,
+    considerMatchedValue: false,
   })
 
   // we use a useEffect that skips the first render


### PR DESCRIPTION
**What problem is this solving?**

When changing, in example, the `selectedItemId`,  the `matched` value was resetted to `undefined`, which made the `Else` and any other condition block to disappear before appearing again, causing a flicker in the layout.

Story: https://app.clubhouse.io/vtex/story/37015/sparkles-condition-layout-else-flickering

**How should this be manually tested?**

1) https://lhx--gympassus.myvtex.com/fresh-and-clean-hand-soap-718/p?skuId=1505
2) Login via dm
3) Keep switching the skus, check if the layout blinks.

**Screenshots or example usage:**

n/a