### PR TITLE
Add product availability condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Product availability condition `isProductAvailable`
+
 ### Changed
 - Updated the example for Readme
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,7 +103,7 @@ Possible values for the `subject` prop:
 | `categoryTree`             | List of categories currentluy displayed on the UI.   | `{ id: string }`  |
 | `specificationProperties`  | List of product specifications currently displayed on the UI. | `{ name: string, value: string }`. Notice: `value` is an optional prop. If omitted, only the specification name (`name`) will be checked. |
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
-| `sellers`                  | List of sellers to product availabilty verification.  | `{ isProductAvailable: boolean }` |
+| `sellers`                  | List of sellers to product availabilty verification.  | No arguments are expected. |
 
 ## Modus Operandi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,7 +103,7 @@ Possible values for the `subject` prop:
 | `categoryTree`             | List of categories currentluy displayed on the UI.   | `{ id: string }`  |
 | `specificationProperties`  | List of product specifications currently displayed on the UI. | `{ name: string, value: string }`. Notice: `value` is an optional prop. If omitted, only the specification name (`name`) will be checked. |
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
-| `sellers`                  | List of sellers to product availabilty verification.  | No arguments are expected. |
+| `isProductAvailable`                  | Whether the product is available (`true`) or not (`false`).  | No arguments are expected. |
 
 ## Modus Operandi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ Possible values for the `subject` prop:
 | `categoryTree`             | List of categories currentluy displayed on the UI.   | `{ id: string }`  |
 | `specificationProperties`  | List of product specifications currently displayed on the UI. | `{ name: string, value: string }`. Notice: `value` is an optional prop. If omitted, only the specification name (`name`) will be checked. |
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
+| `sellers`                  | List of sellers to product availabilty verification.  | `{ isProductAvailable: boolean }` |
 
 ## Modus Operandi
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -72,7 +72,7 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
 
     return specification.values.includes(String(args?.value))
   },
-  isProductAvailable({ values }){
+  isProductAvailable({ values }) {
     return values.isProductAvailable
   },
 }
@@ -101,9 +101,11 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
 
   const { itemId: selectedItemId, sellers } = selectedItem ?? {}
   const sellersWithProductAvailable = sellers?.filter(
-    (sellers) => sellers.commertialOffer.AvailableQuantity > 0
+    (seller) => seller.commertialOffer.AvailableQuantity > 0
   )
-  const isProductAvailable = !!sellersWithProductAvailable && sellersWithProductAvailable.length > 0
+  const isProductAvailable =
+    !!sellersWithProductAvailable &&
+    sellersWithProductAvailable.length > 0
 
   // We use a useMemo to modify the condition layout "values"
   // only when some of the context props change.

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -21,6 +21,7 @@ type SubjectValues = {
   selectedItemId: Item['itemId']
   specificationProperties: Product['properties']
   areAllVariationsSelected: boolean
+  sellers: Item['sellers']
 }
 
 type SubjectArgs = {
@@ -32,6 +33,7 @@ type SubjectArgs = {
   selectedItemId: { id: string }
   specificationProperties: { name: string; value?: string }
   areAllVariationsSelected: undefined
+  sellers: { isProductAvailable: boolean }
 }
 
 export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
@@ -70,6 +72,13 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
 
     return specification.values.includes(String(args?.value))
   },
+  sellers({values, args}){
+    const isProductAvailable = values.sellers.filter(
+      seller => seller.commertialOffer.AvailableQuantity > 0
+    )
+
+    return isProductAvailable.length > 0 === args.isProductAvailable
+  }
 }
 
 const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
@@ -94,7 +103,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     properties: specificationProperties,
   } = product ?? {}
 
-  const { itemId: selectedItemId } = selectedItem ?? {}
+  const { itemId: selectedItemId, sellers } = selectedItem ?? {}
 
   // We use a useMemo to modify the condition layout "values"
   // only when some of the context props change.
@@ -108,6 +117,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
       selectedItemId,
       specificationProperties,
       areAllVariationsSelected,
+      sellers
     }
 
     // We use `NoUndefinedField` to remove optionality + undefined values from the type
@@ -121,6 +131,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     selectedItemId,
     specificationProperties,
     areAllVariationsSelected,
+    sellers
   ])
 
   // Sometimes it takes a while for useProduct() to return the correct results

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -21,7 +21,7 @@ type SubjectValues = {
   selectedItemId: Item['itemId']
   specificationProperties: Product['properties']
   areAllVariationsSelected: boolean
-  isProductAvailable: boolean
+  isProductAvailable: Item['sellers']
 }
 
 type SubjectArgs = {
@@ -73,7 +73,15 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
     return specification.values.includes(String(args?.value))
   },
   isProductAvailable({ values }) {
-    return values.isProductAvailable
+    const { isProductAvailable: sellers } = values
+
+    const sellersWithProductAvailable = sellers?.filter(
+      (seller) => seller.commertialOffer.AvailableQuantity > 0
+    )
+
+    return (
+      !!sellersWithProductAvailable && sellersWithProductAvailable.length > 0
+    )
   },
 }
 
@@ -99,13 +107,8 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     properties: specificationProperties,
   } = product ?? {}
 
-  const { itemId: selectedItemId, sellers } = selectedItem ?? {}
-  const sellersWithProductAvailable = sellers?.filter(
-    (seller) => seller.commertialOffer.AvailableQuantity > 0
-  )
-
-  const isProductAvailable =
-    !!sellersWithProductAvailable && sellersWithProductAvailable.length > 0
+  const { itemId: selectedItemId, sellers: isProductAvailable } =
+    selectedItem ?? {}
 
   // We use a useMemo to modify the condition layout "values"
   // only when some of the context props change.

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -103,9 +103,9 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
   const sellersWithProductAvailable = sellers?.filter(
     (seller) => seller.commertialOffer.AvailableQuantity > 0
   )
+
   const isProductAvailable =
-    !!sellersWithProductAvailable &&
-    sellersWithProductAvailable.length > 0
+    !!sellersWithProductAvailable && sellersWithProductAvailable.length > 0
 
   // We use a useMemo to modify the condition layout "values"
   // only when some of the context props change.

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -33,7 +33,7 @@ type SubjectArgs = {
   selectedItemId: { id: string }
   specificationProperties: { name: string; value?: string }
   areAllVariationsSelected: undefined
-  isProductAvailable: boolean
+  isProductAvailable: undefined
 }
 
 export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -78,7 +78,7 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
     )
 
     return isProductAvailable.length > 0 === args.isProductAvailable
-  }
+  },
 }
 
 const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
@@ -117,7 +117,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
       selectedItemId,
       specificationProperties,
       areAllVariationsSelected,
-      sellers
+      sellers,
     }
 
     // We use `NoUndefinedField` to remove optionality + undefined values from the type
@@ -131,7 +131,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     selectedItemId,
     specificationProperties,
     areAllVariationsSelected,
-    sellers
+    sellers,
   ])
 
   // Sometimes it takes a while for useProduct() to return the correct results

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -21,7 +21,7 @@ type SubjectValues = {
   selectedItemId: Item['itemId']
   specificationProperties: Product['properties']
   areAllVariationsSelected: boolean
-  sellers: Item['sellers']
+  isProductAvailable: boolean
 }
 
 type SubjectArgs = {
@@ -33,7 +33,7 @@ type SubjectArgs = {
   selectedItemId: { id: string }
   specificationProperties: { name: string; value?: string }
   areAllVariationsSelected: undefined
-  sellers: { isProductAvailable: boolean }
+  isProductAvailable: boolean
 }
 
 export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
@@ -72,12 +72,8 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
 
     return specification.values.includes(String(args?.value))
   },
-  sellers({ values, args }){
-    const isProductAvailable = values.sellers.filter(
-      (seller) => seller.commertialOffer.AvailableQuantity > 0
-    )
-
-    return isProductAvailable.length > 0 === args.isProductAvailable
+  isProductAvailable({ values }){
+    return values.isProductAvailable
   },
 }
 
@@ -104,6 +100,10 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
   } = product ?? {}
 
   const { itemId: selectedItemId, sellers } = selectedItem ?? {}
+  const sellersWithProductAvailable = sellers?.filter(
+    (sellers) => sellers.commertialOffer.AvailableQuantity > 0
+  )
+  const isProductAvailable = !!sellersWithProductAvailable && sellersWithProductAvailable.length > 0
 
   // We use a useMemo to modify the condition layout "values"
   // only when some of the context props change.
@@ -117,7 +117,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
       selectedItemId,
       specificationProperties,
       areAllVariationsSelected,
-      sellers,
+      isProductAvailable,
     }
 
     // We use `NoUndefinedField` to remove optionality + undefined values from the type
@@ -131,7 +131,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     selectedItemId,
     specificationProperties,
     areAllVariationsSelected,
-    sellers,
+    isProductAvailable,
   ])
 
   // Sometimes it takes a while for useProduct() to return the correct results

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -75,13 +75,11 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
   isProductAvailable({ values }) {
     const { isProductAvailable: sellers } = values
 
-    const sellersWithProductAvailable = sellers?.filter(
+    const isAvailable = sellers?.some(
       (seller) => seller.commertialOffer.AvailableQuantity > 0
     )
 
-    return (
-      !!sellersWithProductAvailable && sellersWithProductAvailable.length > 0
-    )
+    return Boolean(isAvailable)
   },
 }
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -72,9 +72,9 @@ export const HANDLERS: Handlers<SubjectValues, SubjectArgs> = {
 
     return specification.values.includes(String(args?.value))
   },
-  sellers({values, args}){
+  sellers({ values, args }){
     const isProductAvailable = values.sellers.filter(
-      seller => seller.commertialOffer.AvailableQuantity > 0
+      (seller) => seller.commertialOffer.AvailableQuantity > 0
     )
 
     return isProductAvailable.length > 0 === args.isProductAvailable


### PR DESCRIPTION
#### What problem is this solving?

I created a condition to show or not show blocks based on product availability.

#### How to test it?

[https://dev249--unileverb2b.myvtex.com/](https://dev249--unileverb2b.myvtex.com/)

1. Access this workspace.
2. Click on "Iniciar sesión o registrate"
3. Click on "Crear una cuenta"
4. Register yourself on the store
5. Click on "Iniciar sesión o registrate"
6. Click on "Iniciar sesión"
7. Click on "Recibir código de acceso por e-mail"
8. Fill the input with your email.
9. Click on "Enviar"
10. Check your e-mail to get the code.
11. Fill the input with the received code.
12. Click on "Confirmar"
13. Access a available product (e.g. [link to an available product](https://dev249--unileverb2b.myvtex.com/mimosin-concentrado-suavizante-caricias-58-8lav/p?skuId=29)).
14. See that the buy button, price, sku selector and quantity selector are being shown.
15. Access a unavailable product (e.g. [link to an unavailable product](https://dev249--unileverb2b.myvtex.com/mimosin-concentrado-suavizante-moussel-58-8lav/p?skuId=28)).
16. See that only the sku select is being shown.

#### Screenshots or example usage:

An available product page:

![available_product_page](https://user-images.githubusercontent.com/32344098/97747959-79dad580-1acb-11eb-998a-c07321f1c913.png)

An unavailable product page:

![unavailable_product_page](https://user-images.githubusercontent.com/32344098/97748001-88c18800-1acb-11eb-9fee-dcc64d620e15.png)
