### PR TITLE
Feature/v1 ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Setting `conditionLayoutV1Behaviour` on `vtex.store`, with the option `then-bias`, for allowing SSR of the "then" case of condition layouts.
 
 ## [1.3.0] - 2020-09-30
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,24 @@ The `conditions` prop object has 3 other props, namely `subject`, `verb` and `ob
 
 Lastly, the `match` prop decides the necessary number of valid conditions (defined in `condition.{context}` blocks) for the layout rendering to actually occur.
 
+### Note on server-side rendering
+
+This version doesn't properly support SSR--we recommend using the version 2.x.
+
+However, we've added an option on this version for allowing SSR of the "then" cases: you can enable it on your workspace via the VTEX Toolbelt command:
+
+```
+$ vtex settings set vtex.store conditionLayoutV1Behaviour then-bias
+```
+
+This is recommended for simple conditions, where the majority of cases fall under the `then` case, and where the fail scenario is OK.
+
+To disable it, you can run:
+
+```
+$ vtex settings set vtex.store conditionLayoutV1Behaviour default
+```
+
 ## Customization
 
 The Condition Layout merely establishes a logic to render other blocks. Therefore, the app doesn't have CSS Handles for its specific customization.

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^16.9.49",
     "@vtex/test-tools": "^3.3.2",
     "apollo-client": "^2.6.10",
-    "typescript": "4.0.3",
+    "typescript": "3.9.7",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.1/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.1/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.129.1/public/@types/vtex.styleguide"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5279,12 +5279,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
-
-typescript@^3.9.7:
+typescript@3.9.7, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?
**This PR is for the 1.x version. The 2.x version doesn't have this problem**

Adds setting `conditionLayoutV1Behaviour` on `vtex.store`, with the option `then-bias`, for allowing SSR of the "then" case of condition layouts.

The motivation for this PR is for enabling SSR of specifically the Carrefour PDP but broadly any store that is still using the `condition-layout 1.x`.

<!--- What is the motivation and context for this change? -->

#### How to test it?
https://www.carrefour.com.br/relogio-casio-vintage-unissex-prata-digital-a158wa-1df-8689601/p?workspace=lbebberpdpssr4&v=01

Basically, the SSR should work, unlike the version in production, https://www.carrefour.com.br/relogio-casio-vintage-unissex-prata-digital-a158wa-1df-8689601/p

(to see that the SSR works, just look at the very first render of the page--if it displays product content, the SSR is probably working. A better test would be disabling JS for the page, via DevTools, and seeing the content that comes up)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
