### PR TITLE
fix ind function in categoryTree value property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid breaking if product context is not filled yet.
 
 ## [2.1.2] - 2020-12-22
 ### Fixed

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -59,7 +59,7 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
   },
   categoryTree({ values, args }) {
     return Boolean(
-      values.categoryTree.find(({ id }) => String(id) === String(args?.id))
+      values?.categoryTree?.find(({ id }) => String(id) === String(args?.id))
     )
   },
   specificationProperties({ values, args }) {


### PR DESCRIPTION
#### What problem is this solving?

This PR resolve the problem of this issue https://github.com/vtex-apps/condition-layout/issues/27

#### How to test it?

https://prconditionlayout--tokstokio.myvtex.com/mesa-de-cabeceira-1-gaveta-c-nicho-preto-nozes-lin/p

#### Screenshots or example usage:

When using theTree category as the 'subject' property value of the 'condition layout' component, it is not possible to render the page, because the 'find' function loads before the product context
![image](https://user-images.githubusercontent.com/78028684/105859114-e9793780-5fca-11eb-8889-b98467df3000.png)
![image](https://user-images.githubusercontent.com/78028684/105859161-f7c75380-5fca-11eb-8ba5-471a56c1fae2.png)

This way, we can test within the 'find' method if the property exists before rendering
Before:
![image](https://user-images.githubusercontent.com/78028684/105859509-5c82ae00-5fcb-11eb-83c1-2f861e5d4081.png)
After:
![image](https://user-images.githubusercontent.com/78028684/105859452-4b39a180-5fcb-11eb-9c60-6d682b68ebe6.png)

Result: 
![image](https://user-images.githubusercontent.com/78028684/105859578-715f4180-5fcb-11eb-9d8b-604d169d53fe.png)



#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

![image](https://user-images.githubusercontent.com/78028684/105859696-981d7800-5fcb-11eb-83fb-42b7363a2fde.png)


![](put .gif link here - can be found under "advanced" on giphy)
