### PR TITLE
Feature: Condition Layout Category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - `ConditionLayoutCategory` component. 
 
 ## [2.3.0] - 2021-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `ConditionLayoutCategory` component. 
 
 ## [2.3.0] - 2021-08-02
 ### Added
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `ConditionLayoutBinding` component. 
 
+ 
 ## [2.1.3] - 2021-01-27
 ### Fixed
 - Avoid breaking if product context is not filled yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.2.0] - 2021-07-28
 ### Added
 - `ConditionLayoutBinding` component. 
-
  
 ## [2.1.3] - 2021-01-27
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -186,6 +186,7 @@ Possible values for the` condition-layout.binding`'s `subject` prop:
 | `bindingId` | ID of the desired store binding.  | `{ id: string }` |
 
 Possible values for the `condition-layout.category`'s `subject` prop:
+
 | Subject                    | Description            | Arguments      |
 | -------------------------- | ---------------------- | -------------- |
 | `category`               | Category's IDs currently displayed on the UI.    | `{ ids: string[] }` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,13 +128,13 @@ Or for `condition-layout.category`:
  +   "props": {
  +     "conditions": [
  +       {
- +         "subject": "departmentId",
+ +         "subject": "department",
  +         "arguments": {
  +           "ids": ["1", "42"]
  +         }
  +       }
  +       {
- +         "subject": "categoryId",
+ +         "subject": "category",
  +         "arguments": {
  +           "ids": ["301", "304"]
  +         }
@@ -188,8 +188,8 @@ Possible values for the` condition-layout.binding`'s `subject` prop:
 Possible values for the `condition-layout.category`'s `subject` prop:
 | Subject                    | Description            | Arguments      |
 | -------------------------- | ---------------------- | -------------- |
-| `categoryId`               | Category's IDs currently displayed on the UI.    | `{ ids: string[] }` |
-| `departmentId`             | Department's IDs currently displayed on the UI.  | `{ ids: string[] }` |
+| `category`               | Category's IDs currently displayed on the UI.    | `{ ids: string[] }` |
+| `department`             | Department's IDs currently displayed on the UI.  | `{ ids: string[] }` |
 
 ## Modus Operandi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ You are now able to use all blocks that are exported by the `condition-layout` a
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `condition-layout.product` | Defines the condition logic on the product context and the children blocks that are going to be rendered in case the predefined conditions are met. |
 | `condition-layout.binding` | Defines the condition logic on the current binding and the children blocks that are going to be rendered in case the predefined conditions are met.  |
+| `condition-layout.category` | Defines the condition logic on the current category page or department page and the children blocks that are going to be rendered in case the predefined conditions are met.  |
 
 ### Step 2 - Adding the `condition-layout.product` block to your theme's templates
 
@@ -48,6 +49,16 @@ Or the `condition-layout.binding` block, for example:
 {
   "store.product": {
     "children": ["condition-layout.binding"]
+  }
+}
+```
+
+Or the `condition-layout.category` block, for example:
+
+```json
+{
+  "store.search#my-category-page": {
+    "children": ["condition-layout.category"]
   }
 }
 ```
@@ -106,6 +117,36 @@ Or for `condition-layout.binding`:
 + }
 ```
 
+Or for `condition-layout.category`:
+
+ ```diff
+ {
+   "store.product": {
+     "children": ["condition-layout.category#cond42"]
+   },
+   "condition-layout.category#cond42": {
+ +   "props": {
+ +     "conditions": [
+ +       {
+ +         "subject": "departmentId",
+ +         "arguments": {
+ +           "ids": ["1", "42"]
+ +         }
+ +       }
+ +       {
+ +         "subject": "categoryId",
+ +         "arguments": {
+ +           "ids": ["301", "304"]
+ +         }
+ +       }
+ +     ]
+ +     "matchType": "any",
+ +     "Then": "flex-layout.row#just-for-this-category-or-department",
+ +     "Else": "flex-layout.row#for-other-category-or-department"
+ +   }
+ + }
+ ```
+
 :information_source: *According to the example above, whenever users interact with a product whose ID is equal to 12, the block `flex-layout.row#custom-pdp-layout-12` is rendered. If users interact with a product whose ID is not equal to 12, the rendered block is the `flex-layout.row#default`.*
 
 | Prop name    | Type     | Description  | Default value |
@@ -143,6 +184,12 @@ Possible values for the` condition-layout.binding`'s `subject` prop:
 | Subject | Description | Arguments |
 | -------- | ------------ | ---------- |
 | `bindingId` | ID of the desired store binding.  | `{ id: string }` |
+
+Possible values for the `condition-layout.category`'s `subject` prop:
+| Subject                    | Description            | Arguments      |
+| -------------------------- | ---------------------- | -------------- |
+| `categoryId`               | Category's IDs currently displayed on the UI.    | `{ ids: string[] }` |
+| `departmentId`             | Department's IDs currently displayed on the UI.  | `{ ids: string[] }` |
 
 ## Modus Operandi
 

--- a/react/ConditionLayoutCategory.tsx
+++ b/react/ConditionLayoutCategory.tsx
@@ -5,39 +5,38 @@ import { useRuntime } from 'vtex.render-runtime'
 import ConditionLayout from './ConditionLayout'
 import type { NoUndefinedField, MatchType, Condition, Handlers } from './types'
 
-type Props = {
+interface Props {
   conditions: Array<Condition<ContextValues, HandlerArguments>>
   matchType?: MatchType
   Else?: ComponentType
   Then?: ComponentType
 }
 
-type ContextValues = {
-  id: string,
+interface ContextValues {
+  [key: string]: string
+  id: string
   type: 'category' | 'department'
 }
 
-type HandlerArguments = {
-  categoryId: { ids: string[] }
-  departmentId: { ids: string[] }
+interface HandlerArguments {
+  category: { ids: string[] }
+  department: { ids: string[] }
 }
 
-const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
-  categoryId({ values, args }) {
-    if(values.type === 'category') {
-
-      return args.ids.includes(values.id)
+const handlersMap: Handlers<ContextValues, HandlerArguments> = {
+  category({ values, args }) {
+    if(values.type !== 'category') {
+      return false; 
     }
-
-    return false; 
+    
+    return args.ids.includes(values.id)
   },
-  departmentId({ values, args }) {
-    if(values.type === 'department') {
-      
-      return args.ids.includes(values.id)
+  department({ values, args }) {
+    if(values.type !== 'department') {
+      return false;
     }
-
-    return false;
+    
+    return args.ids.includes(values.id)
   },
 }
 
@@ -49,7 +48,7 @@ const ConditionLayoutCategory: StorefrontFunctionComponent<Props> = ({
   children,
 }) => {
   const { 
-    route: { pageContext: { id, type} },
+    route: { pageContext: { id, type } },
   } = useRuntime()
 
   const values = useMemo<ContextValues>(() => {
@@ -68,7 +67,7 @@ const ConditionLayoutCategory: StorefrontFunctionComponent<Props> = ({
       matchType={matchType}
       conditions={conditions}
       values={values}
-      handlers={HANDLERS}
+      handlers={handlersMap}
     >
       {children}
     </ConditionLayout>

--- a/react/ConditionLayoutCategory.tsx
+++ b/react/ConditionLayoutCategory.tsx
@@ -25,17 +25,17 @@ interface HandlerArguments {
 
 const handlersMap: Handlers<ContextValues, HandlerArguments> = {
   category({ values, args }) {
-    if(values.type !== 'category') {
-      return false; 
+    if (values.type !== 'category') {
+      return false
     }
-    
+
     return args.ids.includes(values.id)
   },
   department({ values, args }) {
-    if(values.type !== 'department') {
-      return false;
+    if (values.type !== 'department') {
+      return false
     }
-    
+
     return args.ids.includes(values.id)
   },
 }
@@ -47,13 +47,16 @@ const ConditionLayoutCategory: StorefrontFunctionComponent<Props> = ({
   conditions,
   children,
 }) => {
-  const { 
-    route: { pageContext: { id, type } },
+  const {
+    route: {
+      pageContext: { id, type },
+    },
   } = useRuntime()
 
   const values = useMemo<ContextValues>(() => {
     const bag = {
-      id, type
+      id,
+      type,
     }
 
     // We use `NoUndefinedField` to remove optionality + undefined values from the type

--- a/react/ConditionLayoutCategory.tsx
+++ b/react/ConditionLayoutCategory.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from 'react'
+import type { ComponentType } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
+
+import ConditionLayout from './ConditionLayout'
+import type { NoUndefinedField, MatchType, Condition, Handlers } from './types'
+
+type Props = {
+  conditions: Array<Condition<ContextValues, HandlerArguments>>
+  matchType?: MatchType
+  Else?: ComponentType
+  Then?: ComponentType
+}
+
+type ContextValues = {
+  id: string,
+  type: 'category' | 'department'
+}
+
+type HandlerArguments = {
+  categoryId: { ids: string[] }
+  departmentId: { ids: string[] }
+}
+
+const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
+  categoryId({ values, args }) {
+    if(values.type === 'category') {
+
+      return args.ids.includes(values.id)
+    }
+
+    return false; 
+  },
+  departmentId({ values, args }) {
+    if(values.type === 'department') {
+      
+      return args.ids.includes(values.id)
+    }
+
+    return false;
+  },
+}
+
+const ConditionLayoutCategory: StorefrontFunctionComponent<Props> = ({
+  Else,
+  Then,
+  matchType,
+  conditions,
+  children,
+}) => {
+  const { 
+    route: { pageContext: { id, type} },
+  } = useRuntime()
+
+  const values = useMemo<ContextValues>(() => {
+    const bag = {
+      id, type
+    }
+
+    // We use `NoUndefinedField` to remove optionality + undefined values from the type
+    return bag as NoUndefinedField<typeof bag>
+  }, [id, type])
+
+  return (
+    <ConditionLayout
+      Else={Else}
+      Then={Then}
+      matchType={matchType}
+      conditions={conditions}
+      values={values}
+      handlers={HANDLERS}
+    >
+      {children}
+    </ConditionLayout>
+  )
+}
+
+export default ConditionLayoutCategory

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -12,5 +12,9 @@
   "condition-layout.binding": {
     "component": "ConditionLayoutBinding",
     "composition": "children"
+  },
+  "condition-layout.category": {
+    "component": "ConditionLayoutCategory",
+    "composition": "children"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Gives ability to render different frontend blocks depending on the current category or department pages.

#### How to test it?

Different category pages display different components.

[Workspace](https://cristi--bestride.myvtex.com/)

#### Screenshots or example usage:

![code](https://user-images.githubusercontent.com/4988454/126614418-10ca0e31-4573-4c28-908e-0db1c6116cc7.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

`vtex.render-runtime`, which was already included

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/26xBsGN2AtMEt7LtC/giphy.gif)
