### PR TITLE
Add hasMoreSKUsThan condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- SKUs quantity condition `hasMoreSKUsThan`
 
 ## [2.3.0] - 2021-08-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - SKUs quantity condition `hasMoreSKUsThan`
 
 ## [2.3.0] - 2021-08-02

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,7 @@ Possible values for the `condition-layout.product`'s `subject` prop:
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
 | `isProductAvailable`                  | Whether the product is available (`true`) or not (`false`).  | No arguments are expected. |
 | `hasMoreSellersThan`                  | Whether the quantity of sellers for the product is more than argument passed.  | `{ quantity: number }`|
+| `hasMoreSKUsThan`                  | Whether the quantity of sku's for the product is more than argument passed.  | `{ quantity: number }`|
 
 Possible values for the` condition-layout.binding`'s `subject` prop:
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -22,6 +22,7 @@ type ContextValues = {
   specificationProperties: Product['properties']
   areAllVariationsSelected: boolean
   sellers: Item['sellers']
+  items: Product['items']
 }
 
 type HandlerArguments = {
@@ -35,6 +36,7 @@ type HandlerArguments = {
   areAllVariationsSelected: undefined
   isProductAvailable: undefined
   hasMoreSellersThan: { quantity: number }
+  hasMoreSKUsThan: { quantity: number }
 }
 
 export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
@@ -93,6 +95,9 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
 
     return isMoreThan
   },
+  hasMoreSKUsThan({ values: { items }, args }) {
+    return items?.length > args?.quantity
+  },
 }
 
 const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
@@ -115,6 +120,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     productClusters,
     categoryTree,
     properties: specificationProperties,
+    items,
   } = product ?? {}
 
   const { itemId: selectedItemId, sellers } = selectedItem ?? {}
@@ -132,6 +138,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
       specificationProperties,
       areAllVariationsSelected,
       sellers,
+      items,
     }
 
     // We use `NoUndefinedField` to remove optionality + undefined values from the type
@@ -146,6 +153,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     specificationProperties,
     areAllVariationsSelected,
     sellers,
+    items,
   ])
 
   // Sometimes it takes a while for useProduct() to return the correct results


### PR DESCRIPTION
#### What problem is this solving?

This change adds a new condition to product page, `hasMoreSKUsThan`

#### How to test it?

[Workspace](https://multiplesku--iviteb.myvtex.com/husa-utv-prowler-hdx/p?skuId=100005)

#### Example usage:

```
"condition-layout.product#multiple": {
    "props": {
      "conditions": [
        {
          "subject": "hasMoreSKUsThan",
          "arguments": {
            "quantity": 3
          }
        }
      ],
      "Then": "rich-text#meaning-of-life",
      "Else": "rich-text#is-always-42"
    }
  },
```

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/7CiWMPL8IZFwq0DLxy/giphy.gif)
