### PR TITLE
Feature/salesChannel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "vtex",
-  "root": true
+  "root": true,
+  "env": {
+    "node": true
+  }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ Or the `condition-layout.category` block, for example:
 
 Now it is time to configure the `condition-layout.product` block!
 
-**Use the block's props to define your layout condition**. You can also declare as the children the `condition-layout.product`'s children some blocks of your choosing to be rendered if the condition is met. 
+**Use the block's props to define your layout condition**. You can also declare as the children the `condition-layout.product`'s children some blocks of your choosing to be rendered if the condition is met.
 
 For example:
 
@@ -208,6 +208,7 @@ Possible values for the` condition-layout.binding`'s `subject` prop:
 | Subject | Description | Arguments |
 | -------- | ------------ | ---------- |
 | `bindingId` | ID of the desired store binding.  | `{ id: string }` |
+| `salesChannel` | IDs of the desired sales channel.  | `{ id: string[] }` |
 
 Possible values for the `condition-layout.category`'s `subject` prop:
 
@@ -249,6 +250,7 @@ Thanks goes out to these wonderful people:
   <tr>
     <td align="center"><a href="https://github.com/LucasCastroAcctGlobal"><img src="https://avatars0.githubusercontent.com/u/55210107?v=4?s=100" width="100px;" alt=""/><br /><sub><b>LucasCastroAcctGlobal</b></sub></a><br /><a href="https://github.com/vtex-apps/condition-layout/commits?author=LucasCastroAcctGlobal" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/vini-lima-acct"><img src="https://avatars.githubusercontent.com/u/78028684?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vini-lima-acct</b></sub></a><br /><a href="https://github.com/vtex-apps/condition-layout/commits?author=vini-lima-acct" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/germanBonacchi"><img src="https://avatars.githubusercontent.com/u/55905671?v=4" width="100px;" alt=""/><br /><sub><b>Germán Bonacchi</b></sub></a><br /><a href="https://github.com/vtex-apps/condition-layout/commits?author=germanBonacchi" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -20,5 +20,11 @@
   "admin/editor.condition-layout.verb.is": "is",
   "admin/editor.condition-layout.verb.is-not": "is not",
   "admin/editor.condition-layout.verb.contains": "contains",
-  "admin/editor.condition-layout.verb.does-not-contain": "does not contain"
+  "admin/editor.condition-layout.verb.does-not-contain": "does not contain",
+  "admin/editor.condition-layout-binding.condition": "Condition Binding block",
+  "admin/editor.condition-layout-binding.conditions": "Conditions Binding",
+  "admin/editor.condition-layout-binding.subject.bindingId": "Selected bindingId",
+  "admin/editor.condition-layout-binding.subject.salesChannel": "Selected Sales Channel"
+
+
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,5 +20,9 @@
   "admin/editor.condition-layout.verb.is": "is",
   "admin/editor.condition-layout.verb.is-not": "is not",
   "admin/editor.condition-layout.verb.contains": "contains",
-  "admin/editor.condition-layout.verb.does-not-contain": "does not contain"
+  "admin/editor.condition-layout.verb.does-not-contain": "does not contain",
+  "admin/editor.condition-layout-binding.condition": "Condition Binding block",
+  "admin/editor.condition-layout-binding.conditions": "Conditions Binding",
+  "admin/editor.condition-layout-binding.subject.bindingId": "Selected bindingId",
+  "admin/editor.condition-layout-binding.subject.salesChannel": "Selected Sales Channel"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -20,5 +20,9 @@
   "admin/editor.condition-layout.verb.is": "es",
   "admin/editor.condition-layout.verb.is-not": "no es",
   "admin/editor.condition-layout.verb.contains": "contiene",
-  "admin/editor.condition-layout.verb.does-not-contain": "no contiene"
+  "admin/editor.condition-layout.verb.does-not-contain": "no contiene",
+  "admin/editor.condition-layout-binding.condition": "Bloque de condición Binding",
+  "admin/editor.condition-layout-binding.conditions": "Condiciones Binding",
+  "admin/editor.condition-layout-binding.subject.bindingId": "BindingId seleccionado",
+  "admin/editor.condition-layout-binding.subject.salesChannel": "Sales Channel seleccionado"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -20,5 +20,9 @@
   "admin/editor.condition-layout.verb.is": "é",
   "admin/editor.condition-layout.verb.is-not": "não é",
   "admin/editor.condition-layout.verb.contains": "contém",
-  "admin/editor.condition-layout.verb.does-not-contain": "não contém"
+  "admin/editor.condition-layout.verb.does-not-contain": "não contém",
+  "admin/editor.condition-layout-binding.condition": "Bloco de condições Binding",
+  "admin/editor.condition-layout-binding.conditions": "Condições Binding",
+  "admin/editor.condition-layout-binding.subject.bindingId": "BindingId selecionado",
+  "admin/editor.condition-layout-binding.subject.salesChannel": "Sales Channel selecionado"
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
       "eslint --fix",
       "prettier --write"
     ],
+    "*.{json,graphql,gql}": [
+      "prettier --write"
+    ],
     "*.json": [
       "prettier --write"
     ]
@@ -28,6 +31,7 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.4.0",
     "prettier": "^2.1.2",
-    "typescript": "^4.0.3"
+    "typescript": "^4.0.3",
+    "vtex.session-client": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client"
   }
 }

--- a/react/ConditionLayoutBinding.tsx
+++ b/react/ConditionLayoutBinding.tsx
@@ -29,8 +29,6 @@ const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     return String(values.bindingId) === String(args?.id)
   },
   salesChannel({ values, args }) {
-    console.log('salesChannel selected', args.id)
-
     return args.id.includes(values.salesChannel)
   }
 }
@@ -48,8 +46,6 @@ const ConditionLayoutBinding: StorefrontFunctionComponent<Props> = ({
 
   const { data } = useFullSession()
   const salesChannel = data?.session?.namespaces?.store?.channel?.value
-
-  console.log("salesChannel of the session", salesChannel)
 
   const values = useMemo<ContextValues>(() => {
     const bag = {

--- a/react/ConditionLayoutBinding.tsx
+++ b/react/ConditionLayoutBinding.tsx
@@ -29,8 +29,7 @@ const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     return String(values.bindingId) === String(args?.id)
   },
   salesChannel({ values, args }) {
-    console.log('handler salesChannel values', values)
-    console.log('handler salesChannel args.ids', args.id)
+    console.log('salesChannel selected', args.id)
 
     return args.id.includes(values.salesChannel)
   }
@@ -50,7 +49,7 @@ const ConditionLayoutBinding: StorefrontFunctionComponent<Props> = ({
   const { data } = useFullSession()
   const salesChannel = data?.session?.namespaces?.store?.channel?.value
 
-  console.log({ salesChannel })
+  console.log("salesChannel of the session", salesChannel)
 
   const values = useMemo<ContextValues>(() => {
     const bag = {

--- a/react/package.json
+++ b/react/package.json
@@ -22,8 +22,10 @@
     "@vtex/test-tools": "^3.3.2",
     "apollo-client": "^2.6.10",
     "typescript": "3.9.7",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context",
+    "vtex.condition-layout": "https://gbo--beautycounterqa.myvtex.com/_v/private/typings/linked/v1/vtex.condition-layout@2.6.0+build1664999427/public/@types/vtex.condition-layout",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.2/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.132.1/public/@types/vtex.styleguide"
+    "vtex.session-client": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide"
   }
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -4,7 +4,12 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": ["es2017", "dom", "es2018.promise", "esnext.asynciterable"],
+    "lib": [
+      "es2017",
+      "dom",
+      "es2018.promise",
+      "esnext.asynciterable"
+    ],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5373,17 +5373,25 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context":
-  version "0.9.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context#f4387e4b4ec59cf7e63b8f68202426a279693dd1"
+"vtex.condition-layout@https://gbo--beautycounterqa.myvtex.com/_v/private/typings/linked/v1/vtex.condition-layout@2.6.0+build1664999427/public/@types/vtex.condition-layout":
+  version "2.6.0"
+  resolved "https://gbo--beautycounterqa.myvtex.com/_v/private/typings/linked/v1/vtex.condition-layout@2.6.0+build1664999427/public/@types/vtex.condition-layout#a212df6a80f08ef91021142a9f149adfeefdf219"
+
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
 
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.2/public/@types/vtex.render-runtime":
   version "8.122.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.2/public/@types/vtex.render-runtime#fa235be2fa6995d12f03f92b20dd3eebb4f3c5fb"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.132.1/public/@types/vtex.styleguide":
-  version "9.132.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.132.1/public/@types/vtex.styleguide#d564344a8c50fa14a78bcd290e02afb0bc492c0f"
+"vtex.session-client@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client":
+  version "1.0.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client#239ac9935a59699e62e1509f844de81544ed0877"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide":
+  version "9.146.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide#05558160f29cd8f4aefe419844a4bd66e2b3fdbb"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -45,7 +45,8 @@
                           "productClusters",
                           "categoryTree",
                           "specificationProperties",
-                          "selectedItemId"
+                          "selectedItemId",
+                          "salesChannel"
                         ],
                         "enumNames": [
                           "admin/editor.condition-layout.product.subject.productId",
@@ -54,7 +55,8 @@
                           "admin/editor.condition-layout.product.subject.productClusters",
                           "admin/editor.condition-layout.product.subject.categoryTree",
                           "admin/editor.condition-layout.product.subject.specificationProperties",
-                          "admin/editor.condition-layout.product.subject.selectedItemId"
+                          "admin/editor.condition-layout.product.subject.selectedItemId",
+                          "admin/editor.condition-layout.product.subject.selectedSalesChannel"
                         ]
                       },
                       "verb": {
@@ -75,7 +77,8 @@
                                 "enum": [
                                   "productClusters",
                                   "categoryTree",
-                                  "specificationProperties"
+                                  "specificationProperties",
+                                  "salesChannel"
                                 ]
                               },
                               "verb": {
@@ -95,7 +98,110 @@
                                   "productId",
                                   "categoryId",
                                   "brandId",
-                                  "selectedItemId"
+                                  "selectedItemId",
+                                  "salesChannel"
+                                ]
+                              },
+                              "verb": {
+                                "default": "is",
+                                "enum": ["is", "is-not"],
+                                "enumNames": [
+                                  "admin/editor.condition-layout.verb.is",
+                                  "admin/editor.condition-layout.verb.is-not"
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ConditionLayoutBinding": {
+      "title": "admin/editor.condition-layout-binding.condition",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "admin/editor.condition-layout.enabled.title",
+          "description": "admin/editor.condition-layout.enabled.description",
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "dependencies": {
+        "enabled": {
+          "oneOf": [
+            {
+              "properties": {
+                "enabled": {
+                  "enum": [true]
+                },
+                "match": {
+                  "default": "all",
+                  "enum": ["any", "none", "all"],
+                  "title": "admin/editor.condition-layout.match",
+                  "type": "string"
+                },
+                "conditions": {
+                  "title": "admin/editor.condition-layout-binding.conditions",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "subject": {
+                        "default": "",
+                        "type": "string",
+                        "title": "admin/editor.condition-layout.subject",
+                        "enum": [
+                          "bindingId",
+                          "salesChannel"
+                        ],
+                        "enumNames": [
+                          "admin/editor.condition-layout-binding.subject.bindingId",
+                          "admin/editor.condition-layout-binding.subject.salesChannel"
+                        ]
+                      },
+                      "verb": {
+                        "type": "string",
+                        "title": "admin/editor.condition-layout.verb"
+                      },
+                      "object": {
+                        "type": "string",
+                        "title": "admin/editor.condition-layout.object"
+                      }
+                    },
+                    "dependencies": {
+                      "subject": {
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "subject": {
+                                "enum": [
+                                  "salesChannel"
+                                ]
+                              },
+                              "verb": {
+                                "default": "contains",
+                                "enum": ["contains", "does-not-contain"],
+                                "enumNames": [
+                                  "admin/editor.condition-layout.verb.contains",
+                                  "admin/editor.condition-layout.verb.does-not-contain"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "subject": {
+                                "enum": [
+                                  "bindingId",
+                                  "salesChannel"
                                 ]
                               },
                               "verb": {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -11,12 +11,15 @@
   },
   "condition-layout.binding": {
     "component": "ConditionLayoutBinding",
-    "composition": "children"
+    "composition": "children",
+    "content": {
+      "$ref": "app:vtex.condition-layout#/definitions/ConditionLayoutBinding"
+    }
   },
   "condition-layout.category": {
     "component": "ConditionLayoutCategory",
     "composition": "children"
-  },  
+  },
   "condition-layout.telemarketing": {
     "component": "ConditionLayoutTelemarketing",
     "composition": "children"


### PR DESCRIPTION
#### What problem is this solving?

Change condition-layout.binding to be able to have the salesChannel as subject 

#### How to test it?

Link and store-theme with a `vtex.condition-layout@2.x:condition-layout.binding` block with condition like this `
"conditions": [
        {
          "subject": "salesChannel",
          "arguments": {
            "id": "2"
          }
        }
      ],
`
[Workspace](https://conditionalsaleschannel--beautycounterqa.myvtex.com)

#### Screenshots or example usage:

![Captura desde 2022-10-11 11-39-59](https://user-images.githubusercontent.com/55905671/195122242-8b539b6d-2d6c-4385-a7de-01c3ca642470.png)
![Captura desde 2022-10-11 11-16-46](https://user-images.githubusercontent.com/55905671/195122348-e5c2d9c2-d173-482a-af96-2bfbea9fe2ca.png)
![Captura desde 2022-10-11 11-43-58](https://user-images.githubusercontent.com/55905671/195123176-8a22f541-5ca8-47e2-940c-098b1dd85d27.png)
![Captura desde 2022-10-11 11-37-36](https://user-images.githubusercontent.com/55905671/195122367-e7dc75cd-f826-43be-bc1f-55e1d69c9a71.png)

