### PR TITLE
Added sellerId condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Seller id(s) condition `sellerId`
+
 ## [2.6.0] - 2022-07-19
 ### Added
 - ConditionLayoutTelemarketing component.

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,6 +202,7 @@ Possible values for the `condition-layout.product`'s `subject` prop:
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
 | `isProductAvailable`                  | Whether the product is available (`true`) or not (`false`).  | No arguments are expected. |
 | `hasMoreSellersThan`                  | Whether the quantity of sellers for the product is more than argument passed.  | `{ quantity: number }`|
+| `sellerId`                            | Whether any of the sellers of the product are included in the list of IDs passed.  | `{ ids: string[] }`|
 
 Possible values for the` condition-layout.binding`'s `subject` prop:
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -35,6 +35,7 @@ type HandlerArguments = {
   areAllVariationsSelected: undefined
   isProductAvailable: undefined
   hasMoreSellersThan: { quantity: number }
+  sellerId: { ids: string[] }
 }
 
 export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
@@ -92,6 +93,19 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     const isMoreThan = productAvailable?.length > args?.quantity
 
     return isMoreThan
+  },
+  sellerId({ values, args }) {
+    const { sellers } = values
+
+    const availableSellers = sellers?.filter(
+      (seller) => seller.commertialOffer.AvailableQuantity > 0
+    )
+
+    const matchSellers = availableSellers?.some((availableSeller) =>
+      args?.ids?.includes(availableSeller.sellerId)
+    )
+
+    return matchSellers
   },
 }
 


### PR DESCRIPTION
#### What problem is this solving?

This change adds a new `sellerId` condition to "condition-layout.product". This solves the need to use conditional layout for product sellers. For example, if you want to show certain blocks only if the product contains a certain seller or any seller from a list. 

You can specify one or more seller IDs, and the condition will be met if the product has a seller ID that matches any of the IDs specified.

#### How to test it?

The following workspace has the condition layout with `sellerId` "1" as argument. Since the current product has seller ID "1", the text "Seller matches!" is displayed above the description. 

https://robertseller--iviteb.myvtex.com/masa-portabila-cu-suport-pentru-reviste-alb-crom-anabel/p

