### PR TITLE
Added hasBestPrice handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Product price discount condition `hasBestPrice`.
+
 ## [2.6.0] - 2022-07-19
 ### Added
 - ConditionLayoutTelemarketing component.

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,6 +202,7 @@ Possible values for the `condition-layout.product`'s `subject` prop:
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
 | `isProductAvailable`                  | Whether the product is available (`true`) or not (`false`).  | No arguments are expected. |
 | `hasMoreSellersThan`                  | Whether the quantity of sellers for the product is more than argument passed.  | `{ quantity: number }`|
+| `hasBestPrice`                  | Whether the product is being given a discount on its list price.  | `{ value: boolean }`|
 
 Possible values for the` condition-layout.binding`'s `subject` prop:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,7 +202,7 @@ Possible values for the `condition-layout.product`'s `subject` prop:
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |
 | `isProductAvailable`                  | Whether the product is available (`true`) or not (`false`).  | No arguments are expected. |
 | `hasMoreSellersThan`                  | Whether the quantity of sellers for the product is more than argument passed.  | `{ quantity: number }`|
-| `hasBestPrice`                  | Whether the product is being given a discount on its list price.  | `{ value: boolean }`|
+| `hasBestPrice`                  | Whether the product is being given a discount on its list price.  | `{ value: boolean }` or no arguments. |
 
 Possible values for the` condition-layout.binding`'s `subject` prop:
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -35,6 +35,7 @@ type HandlerArguments = {
   areAllVariationsSelected: undefined
   isProductAvailable: undefined
   hasMoreSellersThan: { quantity: number }
+  hasBestPrice: { value: boolean }
 }
 
 export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
@@ -92,6 +93,13 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     const isMoreThan = productAvailable?.length > args?.quantity
 
     return isMoreThan
+  },
+  hasBestPrice({ values, args }) {
+    const { ListPrice, Price } = values.sellers[0].commertialOffer
+
+    const hasDiscount = ListPrice !== Price
+
+    return hasDiscount === args.value
   },
 }
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -96,7 +96,12 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     return isMoreThan
   },
   hasBestPrice({ values, args }) {
-    const { ListPrice, Price } = values.sellers[0].commertialOffer
+    const {
+      commertialOffer: { ListPrice, Price },
+    } =
+      values.sellers.find(({ sellerDefault }) => sellerDefault) ??
+      // Falls back to first seller, if no default is found.
+      values.sellers[0]
 
     const expected = args?.value ?? true
     const hasDiscount = ListPrice !== Price

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -35,7 +35,7 @@ type HandlerArguments = {
   areAllVariationsSelected: undefined
   isProductAvailable: undefined
   hasMoreSellersThan: { quantity: number }
-  hasBestPrice: { value: boolean }
+  hasBestPrice: { value: boolean } | undefined
 }
 
 export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
@@ -97,9 +97,10 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
   hasBestPrice({ values, args }) {
     const { ListPrice, Price } = values.sellers[0].commertialOffer
 
+    const expected = args?.value ?? true
     const hasDiscount = ListPrice !== Price
 
-    return hasDiscount === args.value
+    return hasDiscount === expected
   },
 }
 


### PR DESCRIPTION
This new condition option allows developers to create conditions whether the product is on promotion.

#### What problem is this solving?

If a developer wanted to create a different layout for products on promotion, they would need to create a custom component to do that.

This Pull Request implements this solution on `condition-layout.product` block by adding a new condition handler.

#### How to test it?

Create a condition layout like the following:

```json
{
  "condition-layout.product": {
    "props": {
      "conditions": [
        {
          "subject": "hasBestPrice",
          "arguments": {
            "value": true
          }
        }
      ],
      "Then": "rich-text#discount",
      "Else": "rich-text#default"
    }
  },
  "rich-text#discount": {
    "props": {
      "text": "This product contains a discount!!"
    }
  },
  "rich-text#default": {
    "props": {
      "text": "Regular price."
    }
  },
}
```

Also, it is possible to use the shorthand version where no arguments is passed.

```json
{
  "condition-layout.product": {
    "props": {
      "conditions": [
        {
          "subject": "hasBestPrice"
        }
      ],
      "Then": "rich-text#discount",
      "Else": "rich-text#default"
    }
  }
}
```


Upon implementing it, you'll verify that it conditionally renders one over the other based on the list price and selling price diverging.

