### PR TITLE
Add `price` condition

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -203,6 +203,7 @@ Possible values for the `condition-layout.product`'s `subject` prop:
 | `isProductAvailable`                  | Whether the product is available (`true`) or not (`false`).  | No arguments are expected. |
 | `hasMoreSellersThan`                  | Whether the quantity of sellers for the product is more than argument passed.  | `{ quantity: number }`|
 | `sellerId`                            | Whether any of the sellers of the product are included in the list of IDs passed.  | `{ ids: string[] }`|
+| `price`                            | Whether selling price matches the defined _greater than_ and _less than_ conditions. If either argument is ommitted, it will not be checked.  | `{ greaterThan?: number, lessThan?: number }`|
 
 Possible values for the` condition-layout.binding`'s `subject` prop:
 

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -36,6 +36,10 @@ type HandlerArguments = {
   isProductAvailable: undefined
   hasMoreSellersThan: { quantity: number }
   sellerId: { ids: string[] }
+  price: {
+    greaterThan?: number
+    lessThan?: number
+  }
 }
 
 export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
@@ -106,6 +110,20 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     )
 
     return matchSellers
+  },
+  price({ values, args }) {
+    const {
+      sellers: [{ commertialOffer }],
+    } = values
+
+    const { greaterThan, lessThan } = args
+    const price = commertialOffer.Price
+
+    // Both default to true if unset.
+    const matchesGreater = greaterThan ? price > greaterThan : true
+    const matchesLess = lessThan ? price < lessThan : true
+
+    return matchesGreater && matchesLess
   },
 }
 


### PR DESCRIPTION
- feat: add price greater than or less than conditions
- docs: update docs with price condition

#### What problem is this solving?

This PR resolves issue #37.

It adds the  `price` subject condition, which receives two (optional) arguments:

- `greaterThan`: checks if selling price is greater than this value;
- `lessThan`: checks if selling price is cheaper than this value.

#### How to test it?

The following example will check if the selling price is greater than R$ 200,00.

```json
{
  "condition-layout.product": {
    "props": {
      "conditions": [
        {
          "subject": "price",
          "arguments": {
            "greaterThan": 200
          }
        }
      ],
      "Then": "rich-text#discount",
      "Else": "rich-text#default"
    }
  },
  "rich-text#discount": {
    "props": {
      "text": "This product is expensive!!"
    }
  },
  "rich-text#default": {
    "props": {
      "text": "Nothing special here"
    }
  }
}
```

If both conditions are set like in here:
```json
{
  "condition-layout.product": {
    "props": {
      "conditions": [
        {
          "subject": "price",
          "arguments": {
            "greaterThan": 200
            "lessThan": 300
          }
        }
      ],
      "Then": "rich-text#discount",
      "Else": "rich-text#default"
    }
  },
```

It will check if the price is in the range of R$ 200-300,00.

#### Describe alternatives you've considered, if any.

Creating separate `isPriceGreaterThan` and `isPriceLessThan` are also valid implementation, do you think it should be done this way or is it fine as is?

I imagine the way I did can omit the `matchType` prop in some sense, but its up to you, reviewer!
