### PR TITLE
fix: condition product crashing in second consult when using in shelves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Condition Product not considering async values from products
 
 ## [2.8.0] - 2023-04-27
 ### Added

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -57,7 +57,7 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
   },
   productClusters({ values, args }) {
     return Boolean(
-      values.productClusters.find(({ id }) => String(id) === String(args?.id))
+      values.productClusters?.find(({ id }) => String(id) === String(args?.id))
     )
   },
   categoryTree({ values, args }) {
@@ -66,7 +66,7 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     )
   },
   specificationProperties({ values, args }) {
-    const specification = values.specificationProperties.find(
+    const specification = values.specificationProperties?.find(
       ({ name }) => name === args?.name
     )
 
@@ -99,7 +99,7 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
     const {
       commertialOffer: { ListPrice, Price },
     } =
-      values.sellers.find(({ sellerDefault }) => sellerDefault) ??
+      values.sellers?.find(({ sellerDefault }) => sellerDefault) ??
       // Falls back to first seller, if no default is found.
       values.sellers[0]
 


### PR DESCRIPTION
#### What problem is this solving?

When using the condition layout inside search pages, the second consult was crashing due to async information from search products query not being treated by condition product. 

#### How to test it?

[Before](https://tkt776755--caedu.myvtex.com)

Go to the search page searching for something (e.g: camisa) you will see the expected results.

Change your consult, for example, search for "cam" or "blusas", the page is going to crash

<img width="1047" alt="image" src="https://github.com/vtex-apps/condition-layout/assets/13649073/bd872d1b-dcc1-4590-b508-6cfab2e8dd40">

[After](https://iespinoza--caedu.myvtex.com)

Now do the same process for this workspace, everything will work as expected

#### Related to / Depends on

Zendesk: #788321, #822242

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/UOA7c30OGV7jgBye3U/giphy.gif)
