### PR TITLE
feat: add productClusterHighlights handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Product cluster highlight condition `productClusterHighlights`.
+
 ## [2.8.1] - 2023-05-31
 ### Fixed
 - Condition Product not considering async values from products

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,7 @@ Possible values for the `condition-layout.product`'s `subject` prop:
 | `brandId`                  | Brand's IDs currently displayed on the UI.    | `{ id: string }` |
 | `selectedItemId`           | ID of the item currently selected by the user.   | `{ id: string }` |
 | `productClusters`          | List of product clusters currently displayed on the UI.   | `{ id: string }` |
+| `productClusterHighlights` | Product's clusters highlights currently displayed on the UI.   | `{ id: string }` |
 | `categoryTree`             | List of categories currently displayed on the UI. **Note:** only available in the Product Detail Page.   | `{ id: string }`  |
 | `specificationProperties`  | List of product specifications currently displayed on the UI. | `{ name: string, value: string }`. Notice: `value` is an optional prop. If omitted, only the specification name (`name`) will be checked. |
 | `areAllVariationsSelected` | Whether all product variations currently available on the UI were selected by the user (`true`) or not (`false`). | No arguments are expected. |

--- a/react/ConditionLayoutProduct.tsx
+++ b/react/ConditionLayoutProduct.tsx
@@ -17,6 +17,7 @@ type ContextValues = {
   categoryId: Product['categoryId']
   brandId: Product['brandId']
   productClusters: Product['productClusters']
+  clusterHighlights: Product['clusterHighlights']
   categoryTree: Product['categoryTree']
   selectedItemId: Item['itemId']
   specificationProperties: Product['properties']
@@ -29,6 +30,7 @@ type HandlerArguments = {
   categoryId: { id: string }
   brandId: { id: string }
   productClusters: { id: string }
+  productClusterHighlights: { id: string }
   categoryTree: { id: string }
   selectedItemId: { id: string }
   specificationProperties: { name: string; value?: string }
@@ -58,6 +60,11 @@ export const HANDLERS: Handlers<ContextValues, HandlerArguments> = {
   productClusters({ values, args }) {
     return Boolean(
       values.productClusters?.find(({ id }) => String(id) === String(args?.id))
+    )
+  },
+  productClusterHighlights({ values, args }) {
+    return values.clusterHighlights?.some(
+      ({ id }) => String(id) === String(args?.id)
     )
   },
   categoryTree({ values, args }) {
@@ -141,6 +148,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     categoryId,
     brandId,
     productClusters,
+    clusterHighlights,
     categoryTree,
     properties: specificationProperties,
   } = product ?? {}
@@ -155,6 +163,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
       categoryId,
       brandId,
       productClusters,
+      clusterHighlights,
       categoryTree,
       selectedItemId,
       specificationProperties,
@@ -169,6 +178,7 @@ const ConditionLayoutProduct: StorefrontFunctionComponent<Props> = ({
     categoryId,
     categoryTree,
     productClusters,
+    clusterHighlights,
     productId,
     selectedItemId,
     specificationProperties,


### PR DESCRIPTION
#### What problem is this solving?

This new condition option allows developers to create conditions for display product flags. If a developer wanted to create a display conditional on product cluster highlights he could use this subject

#### How to test it?
Create a condition layout like the following:

```json 
 "condition-layout.product#cond1": {
    "props": {
      "conditions": [
        {
          "subject": "productClusterHighlights",
          "arguments": {
            "id": "1802"
          }
        }
      ],
      "Then": "rich-text#flag",
      "Else": "rich-text#no-flag"
    }
  },

  "rich-text#flag": {
    "props": {
      "text": "flag"
    }
  },

  "rich-text#no-flag": {
    "props": {
      "text": "no flag"
    }
  },
  ```


